### PR TITLE
Update error string to be in HTML table format

### DIFF
--- a/bambooContentScript.js
+++ b/bambooContentScript.js
@@ -86,7 +86,7 @@ function main() {
         }
         let timeEntries = entry.getElementsByClassName(timeEntrySelector);
         if (timeEntries.length !== 2 && timeEntries.length !== 0) {
-            htmlString += 'Day does not have exactly 2 entries\n';
+            htmlString += '<tr><td>Day does not have exactly 2 entries</td><td></td><td></td><td></td></tr>';
             continue;
         }
         // console.log('Extracting entry', entry, date, timeEntries);


### PR DESCRIPTION
If this error string isn't in the appropriate HTML table format, it breaks the CSV pasting.
It would add the error string as the first line of the table when pasting into sheets, and offset all following lines.

Now it inserts this error string into the first column of the time sheet.