### PR TITLE
Update script to work with 2023's sheet structure with two entries for saturday

### DIFF
--- a/bambooContentScript.js
+++ b/bambooContentScript.js
@@ -144,18 +144,16 @@ function main() {
                     breakTime = "";
                     breakDuration = "";
                 }
-
-                continue;
-            }
-
-            if (!!previous) {
-                breakTime = `${previous['end']} - ${currentEntry['start']}`;
-                breakDuration = subtractTimes(currentEntry['start'], previous['end']);
             } else {
-                beginning = currentEntry['start'];
+                if (!!previous) {
+                    breakTime = `${previous['end']} - ${currentEntry['start']}`;
+                    breakDuration = subtractTimes(currentEntry['start'], previous['end']);
+                } else {
+                    beginning = currentEntry['start'];
+                }
+                end = currentEntry['end'];
+                previous = currentEntry;
             }
-            end = currentEntry['end'];
-            previous = currentEntry;
         }
 
         if (isSunday && didHaveSat) {

--- a/bambooContentScript.js
+++ b/bambooContentScript.js
@@ -137,8 +137,6 @@ function main() {
                             <td>${satBreakTime}</td>
                         </tr>`.replace(/\s+/g, '');
 
-                    console.log({ satBreakTime, satBreakDuration });
-
                     previous = currentEntry;
                 } else {
                     beginning = currentEntry.start;
@@ -162,7 +160,6 @@ function main() {
 
         if (isSunday && didHaveSat) {
             if (!didHaveSatEntry) {
-                console.log("HERE");
                 htmlString += `<tr><td></td><td></td><td></td><td></td></tr>`;
             }
             didHaveSat = false;


### PR DESCRIPTION
Our google sheets' timesheet structure has changed, there are now __two__ rows for saturday.
This PR updates the script to add the necessary empty rows for the extra saturday entry.
Untested: code for when user has time entry(ies) for saturday.